### PR TITLE
Add draggable category panels

### DIFF
--- a/ytshare/src/app/page.tsx
+++ b/ytshare/src/app/page.tsx
@@ -113,20 +113,41 @@ export default function Home() {
         Manage Categories
       </button>
 
-      {categories.map((c, idx) => (
-        <div
-          key={c.name}
-          className="mb-4 absolute"
-          style={{ left: c.x, top: c.y }}
-        >
-          <button
-            onMouseDown={(e) => startDrag(e, idx)}
-            onClick={() => toggleCat(c.name)}
-            className="w-full flex justify-between items-center bg-gray-700 text-white px-2 py-1 rounded cursor-move"
+        {categories.map((c, idx) => (
+          <div
+            key={c.name}
+            className="mb-4 absolute max-w-sm w-full"
+            style={{ left: c.x, top: c.y }}
           >
-            <span>{c.name}</span>
-            <span className={`transform transition-transform ${openCats[c.name] ? "rotate-90" : ""}`}>▶</span>
-          </button>
+            <button
+              onClick={() => toggleCat(c.name)}
+              className="w-full flex justify-between items-center bg-gray-700 text-white px-2 py-1 rounded"
+            >
+              <span className="flex items-center">
+                <span
+                  onMouseDown={(e) => {
+                    e.stopPropagation();
+                    startDrag(e, idx);
+                  }}
+                  className="mr-2 cursor-move text-gray-300 hover:text-white"
+                >
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    viewBox="0 0 24 24"
+                    fill="currentColor"
+                    className="w-4 h-4"
+                  >
+                    <path d="M4 9h16v2H4zm0 4h16v2H4z" />
+                  </svg>
+                </span>
+                {c.name}
+              </span>
+              <span
+                className={`transform transition-transform ${openCats[c.name] ? "rotate-90" : ""}`}
+              >
+                ▶
+              </span>
+            </button>
           <ul
             className={`grid gap-4 mt-2 md:grid-cols-2 lg:grid-cols-3 transition-all duration-300 ${
               openCats[c.name] ? "max-h-screen" : "max-h-0 overflow-hidden"

--- a/ytshare/src/app/page.tsx
+++ b/ytshare/src/app/page.tsx
@@ -119,6 +119,7 @@ export default function Home() {
             className="mb-4 absolute"
             style={{ left: c.x, top: c.y }}
           >
+
             <button
               onClick={() => toggleCat(c.name)}
               className="w-full max-w-sm flex justify-between items-center bg-gray-700 text-white px-2 py-1 rounded"
@@ -261,7 +262,7 @@ export default function Home() {
       )}
 
       {showCatEditor && (
-        <div className="fixed inset-0 bg-black bg-opacity-80 flex items-center justify-center z-50">
+        <div className="fixed inset-0 bg-black/80 flex items-center justify-center z-50">
           <div className="bg-gray-800 p-6 rounded-lg shadow-lg w-full max-w-md text-white">
             <div className="flex justify-between items-center mb-4">
               <h2 className="text-lg font-semibold">Category positions</h2>

--- a/ytshare/src/app/page.tsx
+++ b/ytshare/src/app/page.tsx
@@ -116,12 +116,12 @@ export default function Home() {
         {categories.map((c, idx) => (
           <div
             key={c.name}
-            className="mb-4 absolute max-w-sm w-full"
+            className="mb-4 absolute"
             style={{ left: c.x, top: c.y }}
           >
             <button
               onClick={() => toggleCat(c.name)}
-              className="w-full flex justify-between items-center bg-gray-700 text-white px-2 py-1 rounded"
+              className="w-full max-w-sm flex justify-between items-center bg-gray-700 text-white px-2 py-1 rounded"
             >
               <span className="flex items-center">
                 <span


### PR DESCRIPTION
## Summary
- let categories have coordinates and be draggable
- tweak category header size
- allow manual position editing via new overlay

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685298648460832980db2089a79a2f26